### PR TITLE
Use steam.steamid to get user's steam64_id from their profile link

### DIFF
--- a/discord_app.py
+++ b/discord_app.py
@@ -3,6 +3,7 @@ import discord
 from discord.ext import commands
 import logging  # receives logs from discord.py
 from datetime import datetime
+from steam import steamid
 
 logging.basicConfig(level=logging.INFO)
 
@@ -64,7 +65,7 @@ async def on_message(message: discord.Message):
         'discord_name': str(message.author),
         'discord_id': message.author.id,
         'popflash_id': popflash_id,
-        'steam': profile['steam'],
+        'steam_id': steamid.steam64_from_url(profile["steam_profile"]),
         'register_date': datetime.now(),
         'v': profile['v'],
     }

--- a/discord_app.py
+++ b/discord_app.py
@@ -65,7 +65,7 @@ async def on_message(message: discord.Message):
         'discord_name': str(message.author),
         'discord_id': message.author.id,
         'popflash_id': popflash_id,
-        'steam_id': steamid.steam64_from_url(profile["steam_profile"]),
+        'steam_id': int(steamid.steam64_from_url(profile["steam_profile"])),
         'register_date': datetime.now(),
         'v': profile['v'],
     }

--- a/popflash_api.py
+++ b/popflash_api.py
@@ -34,9 +34,9 @@ def get_profile(url):
   df = pd.read_html(str(tab), header=0)[0]
   df['match_link'] = _strip_links_from_table(tab)
 
-  steam = soup.select('#page-container > div:nth-child(2) > div > div:nth-child(1) > h3 > span.steam-profile > a')[0]['href']
+  steam_profile = soup.select('#page-container > div:nth-child(2) > div > div:nth-child(1) > h3 > span.steam-profile > a')[0]['href']
 
-  return {'match_table': df, 'id': url.split('/')[-1], 'name': name, 'steam': steam, 'v': API_VERSION}
+  return {'match_table': df, 'id': url.split('/')[-1], 'name': name, 'steam_profile': steam_profile, 'v': API_VERSION}
 
 def get_match(url):
   if isinstance(url, int):


### PR DESCRIPTION
Messaging RatingBot with your Popflash profile link was storing a link to your Steam profile in the database as `steam`. This was out of sync with the rest of the database, that was storing `steam_id`. Here I've used `steam.steamid.steam64_from_url` to get the user's steam64_id from their Steam profile link, and store the steam64_id as `steam_id` in the database..